### PR TITLE
kestra:latest-full is no more maintained

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       retries: 10
 
   kestra:
-    image: kestra/kestra:latest-full
+    image: kestra/kestra:latest
     entrypoint: /bin/bash
     user: "root"
     env_file:


### PR DESCRIPTION
We've just updated the docs in this spirit, and I thought it could be valuable here as well!

See [_Docker image tags_ in v0.18 announcement](https://kestra.io/blogs/2024-08-06-release-0-18#docker-image-tags)